### PR TITLE
Fix assert! macro usage

### DIFF
--- a/src/generators/phrase.rs
+++ b/src/generators/phrase.rs
@@ -196,7 +196,7 @@ mod test {
             passwords
                 .words
                 .into_iter()
-                .all(|word| word.len() >= 5);
+                .all(|word| word.len() >= 5)
         )
     }
 


### PR DESCRIPTION
There is a bug in rustc that allows adding invalid trailing tokens to the `assert!` macro call. They are currently ignored but are going to produce errors in the future.

Fix assert! macro usage to remove extra tokens.

For more information, see https://github.com/rust-lang/rust/issues/60024 and https://github.com/rust-lang/rust/pull/60039
